### PR TITLE
Feature - update multi-children type to use ReactNode instead of React.Child

### DIFF
--- a/src/parentComponentProps.ts
+++ b/src/parentComponentProps.ts
@@ -9,9 +9,13 @@ export interface IMultiChildProps<PropsType> {
 }
 
 export interface ISingleAnyChildProps {
-  children: React.ReactChild;
+  children: React.ReactNode;
+}
+
+export interface IOptionalSingleAnyChildProps {
+  children?: React.ReactNode;
 }
 
 export interface IMultiAnyChildProps {
-  children?: React.ReactChild | React.ReactChild[];
+  children?: React.ReactNode | React.ReactNode[];
 }


### PR DESCRIPTION
See differences here https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/v16/index.d.ts#L239

Most importantly, ReactNode allows children to be fragments, booleans and nulls too (so e.g. `{ condition && <Comp />}` is a valid child

